### PR TITLE
Count characters instead of bytes.

### DIFF
--- a/Commands/Word Count.plist
+++ b/Commands/Word Count.plist
@@ -11,10 +11,10 @@ def pretty(number)
   number.to_s.gsub(/\d{1,3}(?=\d{3}+(?!\d))/, '\0,')
 end
 
-counts = `wc -lwc`.scan(/\d+/)
+counts = `wc -lwm`.scan(/\d+/)
 counts[0] = counts[0].to_i + 1 # increase one to the line count
 
-%w[ line word byte ].each do |unit|
+%w[ line word character ].each do |unit|
   cnt    = counts.shift
   plural = cnt.to_i != 1 ? 's' : ''
   printf("%11.11s %s%s\n", pretty(cnt), unit, plural)
@@ -24,13 +24,21 @@ end
 	<string>document</string>
 	<key>input</key>
 	<string>selection</string>
+	<key>inputFormat</key>
+	<string>text</string>
 	<key>keyEquivalent</key>
 	<string>^N</string>
 	<key>name</key>
 	<string>Statistics for Document / Selection (Word Count)</string>
-	<key>output</key>
-	<string>showAsTooltip</string>
+	<key>outputCaret</key>
+	<string>afterOutput</string>
+	<key>outputFormat</key>
+	<string>text</string>
+	<key>outputLocation</key>
+	<string>toolTip</string>
 	<key>uuid</key>
 	<string>AA202E76-8A0A-11D9-B85D-000D93589AF6</string>
+	<key>version</key>
+	<integer>2</integer>
 </dict>
 </plist>


### PR DESCRIPTION
`wc -m` handles multibyte characters correctly (depending on the current locale).

I think this makes more sense than counting raw bytes.
