### PR TITLE
Added LANG=C for sorting multi byte characters

### DIFF
--- a/Commands/Reverse Sort.plist
+++ b/Commands/Reverse Sort.plist
@@ -8,6 +8,7 @@
 	<string>#!/usr/bin/env bash
 [[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
 
+LANG=C
 sort -rf</string>
 	<key>fallbackInput</key>
 	<string>document</string>

--- a/Commands/Sort & Uniq.plist
+++ b/Commands/Sort & Uniq.plist
@@ -8,6 +8,7 @@
 	<string>#!/usr/bin/env bash
 [[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
 
+LANG=C
 sort -f|uniq</string>
 	<key>input</key>
 	<string>selection</string>

--- a/Commands/Sort.plist
+++ b/Commands/Sort.plist
@@ -8,6 +8,7 @@
 	<string>#!/usr/bin/env bash
 [[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
 
+LANG=C
 sort -f</string>
 	<key>fallbackInput</key>
 	<string>document</string>


### PR DESCRIPTION
when sorting multi byte characters

```
ぐ
グ
れ
力
す
```

it causes an error message below.

```
sort: string comparison failed: Illegal byte sequence
sort: Set LC_ALL='C' to work around the problem.
sort: The strings compared were `Ŋ\233' and `Á\231'.
```
