### PR TITLE
Add convert from UTF-8-MAC to UTF-8

### DIFF
--- a/Commands/UTF-8-MAC to UTF-8.tmCommand
+++ b/Commands/UTF-8-MAC to UTF-8.tmCommand
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>beforeRunningCommand</key>
+	<string>nop</string>
+	<key>command</key>
+	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
+
+require 'iconv'
+print Iconv.conv('UTF-8', 'UTF-8-MAC', STDIN.read)
+
+# if 1.9 or later
+# print STDIN.read.encode("UTF-8", "UTF-8-MAC")
+</string>
+	<key>input</key>
+	<string>selection</string>
+	<key>inputFormat</key>
+	<string>text</string>
+	<key>keyEquivalent</key>
+	<string>^M</string>
+	<key>name</key>
+	<string>UTF-8-MAC to UTF-8</string>
+	<key>outputCaret</key>
+	<string>selectOutput</string>
+	<key>outputFormat</key>
+	<string>text</string>
+	<key>outputLocation</key>
+	<string>replaceInput</string>
+	<key>uuid</key>
+	<string>A246CFE7-FFBD-460F-BD07-DC506A002709</string>
+	<key>version</key>
+	<integer>2</integer>
+</dict>
+</plist>

--- a/info.plist
+++ b/info.plist
@@ -83,6 +83,7 @@
 					<string>0F8C1F78-6E4C-11D9-91AF-000D93589AF6</string>
 					<string>BEC25DC3-6E4B-11D9-91AF-000D93589AF6</string>
 					<string>3AA8A593-6E4C-11D9-91AF-000D93589AF6</string>
+					<string>A246CFE7-FFBD-460F-BD07-DC506A002709</string>
 				</array>
 				<key>name</key>
 				<string>Converting / Stripping</string>


### PR DESCRIPTION
Command for converting characters from NFD (Normalization Form D) to NFC (Normalization Form D)

for example

**NFD**
`バ` (0x30cf 0x3099)
-> `ハ` + `゛`
non OSX system loooks like this

**NFC**
`バ` (0x30d0) 
